### PR TITLE
hotfix: 

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,8 +16,8 @@ android {
         applicationId = "org.marklackey.android.awake"
         minSdk = 24
         targetSdk = 35
-        versionCode = 14
-        versionName = "11.1"
+        versionCode = 15
+        versionName = "11.2"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -22,6 +22,9 @@
 -keepattributes Signature
 -keep class com.google.gson.reflect.TypeToken { *; }
 -keep class * extends com.google.gson.reflect.TypeToken
+-keepattributes Signature
+-keep class com.simplyawakeremake.data.**.remote.** { *; }
+
 
 
 #############################################

--- a/app/src/main/java/com/simplyawakeremake/data/track/remote/TrackDto.kt
+++ b/app/src/main/java/com/simplyawakeremake/data/track/remote/TrackDto.kt
@@ -1,10 +1,12 @@
 package com.simplyawakeremake.data.track.remote
 
+import androidx.annotation.Keep
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
 
 
 data class TrackDto(
+    @Expose
     @SerializedName("id")
     val id: String,
     @Expose

--- a/app/src/main/java/com/simplyawakeremake/data/user/UserDto.kt
+++ b/app/src/main/java/com/simplyawakeremake/data/user/UserDto.kt
@@ -1,6 +1,9 @@
 package com.simplyawakeremake.data.user
 
+import androidx.annotation.Keep
 
+
+@Keep
 data class UserDto(
     val id: String,
     val firebaseUid: String?,

--- a/app/src/main/java/com/simplyawakeremake/data/usertrack/remote/UserTrackDto.kt
+++ b/app/src/main/java/com/simplyawakeremake/data/usertrack/remote/UserTrackDto.kt
@@ -1,7 +1,9 @@
 package com.simplyawakeremake.data.usertrack.remote
 
+import androidx.annotation.Keep
 import com.simplyawakeremake.data.usertrack.UserTrack
 
+@Keep
 data class UserTrackDto(
     val userId: String = "",
     val trackId: String = "",


### PR DESCRIPTION
This commit enables minification for debug builds and applies ProGuard rules to ensure data transfer objects are preserved during the obfuscation process.

Key changes:
- **Build Configuration**:
    - Enabled `isMinifyEnabled` for the `debug` build type.
    - Updated `versionCode` to 15 and `versionName` to 11.2.
- **ProGuard/R8 Rules**:
    - Added `@Keep` annotations to `UserDto` and `UserTrackDto` to prevent them from being stripped or obfuscated.
    - Added an `@Expose` annotation to the `id` field in `TrackDto`.
    - Updated `proguard-rules.pro` to keep all classes within remote data packages.